### PR TITLE
Colocate user graphql setup

### DIFF
--- a/api/schema/User.ts
+++ b/api/schema/User.ts
@@ -7,3 +7,11 @@ schema.objectType({
     t.model.email();
   },
 });
+
+schema.extendType({
+  type: "Query",
+  definition(t) {
+    t.crud.user();
+    t.crud.users();
+  },
+});

--- a/api/schema/index.ts
+++ b/api/schema/index.ts
@@ -1,2 +1,1 @@
-import "./query";
-import "./models/user";
+import "./User";

--- a/api/schema/query.ts
+++ b/api/schema/query.ts
@@ -1,8 +1,0 @@
-import { schema } from "nexus";
-
-schema.queryType({
-  definition(t) {
-    t.crud.user();
-    t.crud.users();
-  },
-});


### PR DESCRIPTION
Instead of centralizing queries, mutations, etc, and having "models" stand on their own as field definitions, this PR colocates the model along with relevant queries, mutations, etc.