### PR TITLE
Only run codeql on cron

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,9 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
Because it's slow as balls on push and PR events.